### PR TITLE
Add DependencyGraph.contains

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,69 @@
+{
+  "originHash" : "bc8d50111a62c3807994e37d05c525a786ed2a6341d41f241438eac9ae0fb3d0",
+  "pins" : [
+    {
+      "identity" : "cwlcatchexception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlCatchException.git",
+      "state" : {
+        "revision" : "07b2ba21d361c223e25e3c1e924288742923f08c",
+        "version" : "2.2.1"
+      }
+    },
+    {
+      "identity" : "cwlpreconditiontesting",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+      "state" : {
+        "revision" : "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+        "version" : "2.2.2"
+      }
+    },
+    {
+      "identity" : "nimble",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Nimble.git",
+      "state" : {
+        "revision" : "edaedc1ec86f14ac6e2ca495b94f0ff7150d98d0",
+        "version" : "12.3.0"
+      }
+    },
+    {
+      "identity" : "quick",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Quick/Quick.git",
+      "state" : {
+        "revision" : "1163a1b1b114a657c7432b63dd1f92ce99fe11a6",
+        "version" : "7.6.2"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
+        "version" : "1.0.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -5,11 +5,16 @@ import PackageDescription
 
 let package = Package(
     name: "swift-dependency-graphs",
+    platforms: [.macOS(.v10_15)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "swift-dependency-graphs",
             targets: ["swift-dependency-graphs"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Quick/Quick.git", from: "7.0.0"),
+        .package(url: "https://github.com/Quick/Nimble.git", from: "12.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -18,7 +23,7 @@ let package = Package(
             name: "swift-dependency-graphs"),
         .testTarget(
             name: "swift-dependency-graphsTests",
-            dependencies: ["swift-dependency-graphs"]
+            dependencies: ["swift-dependency-graphs", "Quick", "Nimble"]
         ),
     ]
 )

--- a/Sources/SwiftDependencyGraphs/DependencyGraph.swift
+++ b/Sources/SwiftDependencyGraphs/DependencyGraph.swift
@@ -1,0 +1,40 @@
+public struct DependencyGraph<V> where V: Hashable, V: Identifiable {
+    typealias Edge = (V, V)
+    
+    /// The vertices of the dependency graph.
+    public internal(set) var vertices: [V.ID: V] = [:]
+    
+    // For efficiency, two hashsets are maintained.
+    /**
+     Incoming edges of a vertex are directed edges that the vertex is the destination.
+     
+     The edge `v --> w` (or `(v, w)`) is an incoming edge of `w`, but not of `v`.
+     In this case, `w` is a key and `v` its value.
+     
+     - Note: Informally speaking, `v` is adjacent to `w`, or a neighbour of `w`, and
+     `w` is targeted by `v`'s arrow.
+     */
+    public internal(set) var incoming_edges: [V.ID: Set<V>] = [:]
+    
+    /**
+     Outgoing edges of a vertex are directed edges that the vertex is the origin.
+     
+     The edge `v --> w` (or `(v, w)`) is an outgoing edge of `v`, but not of `w`.
+     In this case, `v` is a key and `w` its value.
+     
+     - Note: Informally speaking, `v` is adjacent to `w`, or a neighbour of `w`, and
+     its arrow points to `w`.
+     */
+    public internal(set) var outgoing_edges: [V.ID: Set<V>] = [:]
+    
+    func contains(vertex: V) -> Bool {
+        return contains(vertexWith: {v in v.id == vertex.id})
+    }
+    
+    /**
+     Returns `true` iff at least one vertex satifies the `predicate`.
+     */
+    func contains(vertexWith predicate: (V) -> Bool) -> Bool {
+        return vertices.contains(where: {_, vertex in predicate(vertex)})
+    }
+}

--- a/Tests/SwiftDependencyGraphsTests/ContainsVertexWithTests.swift
+++ b/Tests/SwiftDependencyGraphsTests/ContainsVertexWithTests.swift
@@ -1,0 +1,60 @@
+import Quick
+import Nimble
+@testable import swift_dependency_graphs
+
+class ContainsVertexWithTests: QuickSpec {
+    override class func spec() {
+
+        // C4 has only vertices with the ids 1, 2, 3 and 4.
+        let vertex_1_prime_with_same_label = Vertex(id: 5, label: "1")
+        let vertex_1_prime_with_same_id = Vertex(id: vertex_1.id, label: "not 1")
+        
+        describe("C4 with vertices v1, v2, v3 and v4") {
+            it("contains the vertex v1") {
+                expect(TestGraph.directedC4().contains(vertex: vertex_1)).to(beTrue())
+            }
+            
+            it("does not contain the vertex v5") {
+                expect(TestGraph.directedC4().contains(vertex: vertex_5)).to(beFalse())
+            }
+            
+            it("contains the vertex v1' with v1' ≠ v1 and v1'.id = v1.id") {
+                expect(TestGraph.directedC4().contains(vertex: vertex_1_prime_with_same_id)).to(beTrue())
+            }
+            
+            it("does not contain the vertex v1' with v1' ≠ v1 and v1'.label = v1.label") {
+                expect(TestGraph.directedC4().contains(vertex: vertex_1_prime_with_same_label)).to(beFalse())
+            }
+            
+            it("contains a vertex with an odd id") {
+                expect(TestGraph.directedC4().contains(vertexWith: {v in !v.id.isMultiple(of: 2)})).to(beTrue())
+            }
+            
+            it("does not contain a vertex with an id that is divisible by 5") {
+                expect(TestGraph.directedC4().contains(vertexWith: {v in v.id.isMultiple(of: 5)})).to(beFalse())
+            }
+            
+            it("contains a vertex with a label that starts with 3") {
+                expect(TestGraph.directedC4().contains(vertexWith: {v in v.label.starts(with: "3")})).to(beTrue())
+            }
+            
+            it("does not contain a vertex with a label that ends with .") {
+                expect(TestGraph.directedC4().contains(vertexWith: {v in v.label.hasSuffix(".")})).to(beFalse())
+            }
+        }
+        
+        describe("the empty graph") {
+            it("does not contain the vertex v") {
+                expect(TestGraph.empty.contains(vertex: vertex_1)).to(beFalse())
+            }
+            
+            it("does not contain a vertex with an even id") {
+                expect(TestGraph.empty.contains(vertexWith: {v in v.id.isMultiple(of: 2)})).to(beFalse())
+            }
+            
+            it("does not contain a vertex with a label that starts with a") {
+                expect(TestGraph.empty.contains(vertexWith: {v in v.label.starts(with: "a")})).to(beFalse())
+            }
+        }
+    }
+}

--- a/Tests/SwiftDependencyGraphsTests/Helpers/TestGraph.swift
+++ b/Tests/SwiftDependencyGraphsTests/Helpers/TestGraph.swift
@@ -1,0 +1,40 @@
+@testable import swift_dependency_graphs
+
+typealias TestGraph = DependencyGraph<Vertex>
+
+extension TestGraph {
+    /**
+     Returns an empty graph.
+     */
+    static var empty: TestGraph { DependencyGraph() }
+    
+    /**
+     The graph C4 looks like this: 1 --> 2 --> 3 --> 4 --> 1.
+     
+     - Returns: The graph C4.
+     - Note: The directed cyclic graph on 4 vertices is usually denoted by $C^4$ or $C\_4$.
+     */
+    static func directedC4() -> TestGraph {
+        var c4 = TestGraph()
+        c4.vertices = [
+            vertex_1.id: vertex_1,
+            vertex_2.id: vertex_2,
+            vertex_3.id: vertex_3,
+            vertex_4.id: vertex_4,
+        ]
+        c4.incoming_edges = [
+            vertex_1.id: [vertex_4],
+            vertex_2.id: [vertex_1],
+            vertex_3.id: [vertex_2],
+            vertex_4.id: [vertex_3],
+        ]
+        c4.outgoing_edges = [
+            vertex_1.id: [vertex_2],
+            vertex_2.id: [vertex_3],
+            vertex_3.id: [vertex_4],
+            vertex_4.id: [vertex_1],
+        ]
+            
+        return c4
+    }
+}

--- a/Tests/SwiftDependencyGraphsTests/Helpers/Vertex.swift
+++ b/Tests/SwiftDependencyGraphsTests/Helpers/Vertex.swift
@@ -1,0 +1,22 @@
+/**
+ In comments or descriptions, a vertex with `id` `n` is referred to as `v${n}`.
+ Just using the `id` or the `label` may be confusing.
+ */
+struct Vertex: Identifiable, Hashable {
+    let id: Int
+    /// `label` is used for testing how the library handles properties.
+    let label: String
+}
+
+let vertex_1 = Vertex(id: 1)
+let vertex_2 = Vertex(id: 2)
+let vertex_3 = Vertex(id: 3)
+let vertex_4 = Vertex(id: 4)
+let vertex_5 = Vertex(id: 5)
+
+extension Vertex {
+    /// Convenience to also use `id` to set `label`.
+    init(id: Int) {
+        self.init(id: id, label: "\(id)")
+    }
+}


### PR DESCRIPTION
Methods that check for membership of vertices are required for more sophisticated methods. Examples for such methods are adding a vertex or finding all neighbours of a vertex.  When adding a vertex, we first want to make sure that the vertex does not exist already because we do not want to override its entries in the dictionaries.

TestGraph was added to avoid code duplication. By using graphs with well-studied properties, we reduce the errors in the test specifications. For example, cyclic graphs are not acyclic. For custom graphs, we have to check this ourselves.

Quick and Nimble were added because they improve the readability of tests.

Related to: #4
See also: #1