### PR TITLE
Replace Set with OrderedSet

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bc8d50111a62c3807994e37d05c525a786ed2a6341d41f241438eac9ae0fb3d0",
+  "originHash" : "f04308f5e2fe4f6b23327284830412aa37f3c0e342eab06d3800985bd393a95e",
   "pins" : [
     {
       "identity" : "cwlcatchexception",
@@ -53,6 +53,15 @@
       "state" : {
         "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
         "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,20 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Quick/Quick.git", from: "7.0.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "12.0.0"),
+        .package(
+              url: "https://github.com/apple/swift-collections.git",
+              .upToNextMinor(from: "1.1.0")
+            )
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "swift-dependency-graphs"),
+            name: "swift-dependency-graphs",
+            dependencies: [
+                .product(name: "Collections", package: "swift-collections")
+            ]
+        ),
         .testTarget(
             name: "swift-dependency-graphsTests",
             dependencies: ["swift-dependency-graphs", "Quick", "Nimble"]

--- a/Sources/SwiftDependencyGraphs/DependencyGraph.swift
+++ b/Sources/SwiftDependencyGraphs/DependencyGraph.swift
@@ -1,3 +1,5 @@
+import OrderedCollections
+
 public struct DependencyGraph<V> where V: Hashable, V: Identifiable {
     typealias Edge = (V, V)
     
@@ -14,7 +16,7 @@ public struct DependencyGraph<V> where V: Hashable, V: Identifiable {
      - Note: Informally speaking, `v` is adjacent to `w`, or a neighbour of `w`, and
      `w` is targeted by `v`'s arrow.
      */
-    public internal(set) var incoming_edges: [V.ID: Set<V>] = [:]
+    public internal(set) var incoming_edges: [V.ID: OrderedSet<V>] = [:]
     
     /**
      Outgoing edges of a vertex are directed edges that the vertex is the origin.
@@ -25,7 +27,7 @@ public struct DependencyGraph<V> where V: Hashable, V: Identifiable {
      - Note: Informally speaking, `v` is adjacent to `w`, or a neighbour of `w`, and
      its arrow points to `w`.
      */
-    public internal(set) var outgoing_edges: [V.ID: Set<V>] = [:]
+    public internal(set) var outgoing_edges: [V.ID: OrderedSet<V>] = [:]
     
     func contains(vertex: V) -> Bool {
         return contains(vertexWith: {v in v.id == vertex.id})


### PR DESCRIPTION
Using ordered sets in the dictionaries for vertices will be useful in tests for depth-first search. Ordered sets allow us to specify in which order the graph will traverse the vertices.

Related to: https://github.com/ikelax/swift-dependency-graphs/issues/1