### PR TITLE
Rename package to DependencyGraph in code

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,16 +1,16 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
-    name: "swift-dependency-graphs",
+    name: "DependencyGraphs",
     platforms: [.macOS(.v10_15)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
-            name: "swift-dependency-graphs",
-            targets: ["swift-dependency-graphs"]),
+            name: "DependencyGraphs",
+            targets: ["DependencyGraphs"]),
     ],
     dependencies: [
         .package(url: "https://github.com/Quick/Quick.git", from: "7.0.0"),
@@ -24,14 +24,14 @@ let package = Package(
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "swift-dependency-graphs",
+            name: "DependencyGraphs",
             dependencies: [
                 .product(name: "Collections", package: "swift-collections")
             ]
         ),
         .testTarget(
-            name: "swift-dependency-graphsTests",
-            dependencies: ["swift-dependency-graphs", "Quick", "Nimble"]
+            name: "DependencyGraphsTests",
+            dependencies: ["DependencyGraphs", "Quick", "Nimble"]
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "DependencyGraphs",
+    name: "swift-dependency-graphs",
     platforms: [.macOS(.v10_15)],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/Tests/SwiftDependencyGraphsTests/ContainsVertexWithTests.swift
+++ b/Tests/SwiftDependencyGraphsTests/ContainsVertexWithTests.swift
@@ -1,6 +1,6 @@
 import Quick
 import Nimble
-@testable import swift_dependency_graphs
+@testable import DependencyGraphs
 
 class ContainsVertexWithTests: QuickSpec {
     override class func spec() {
@@ -8,50 +8,50 @@ class ContainsVertexWithTests: QuickSpec {
         // C4 has only vertices with the ids 1, 2, 3 and 4.
         let vertex_1_prime_with_same_label = Vertex(id: 5, label: "1")
         let vertex_1_prime_with_same_id = Vertex(id: vertex_1.id, label: "not 1")
-        
+
         describe("C4 with vertices v1, v2, v3 and v4") {
             it("contains the vertex v1") {
                 expect(TestGraph.directedC4().contains(vertex: vertex_1)).to(beTrue())
             }
-            
+
             it("does not contain the vertex v5") {
                 expect(TestGraph.directedC4().contains(vertex: vertex_5)).to(beFalse())
             }
-            
+
             it("contains the vertex v1' with v1' ≠ v1 and v1'.id = v1.id") {
                 expect(TestGraph.directedC4().contains(vertex: vertex_1_prime_with_same_id)).to(beTrue())
             }
-            
+
             it("does not contain the vertex v1' with v1' ≠ v1 and v1'.label = v1.label") {
                 expect(TestGraph.directedC4().contains(vertex: vertex_1_prime_with_same_label)).to(beFalse())
             }
-            
+
             it("contains a vertex with an odd id") {
                 expect(TestGraph.directedC4().contains(vertexWith: {v in !v.id.isMultiple(of: 2)})).to(beTrue())
             }
-            
+
             it("does not contain a vertex with an id that is divisible by 5") {
                 expect(TestGraph.directedC4().contains(vertexWith: {v in v.id.isMultiple(of: 5)})).to(beFalse())
             }
-            
+
             it("contains a vertex with a label that starts with 3") {
                 expect(TestGraph.directedC4().contains(vertexWith: {v in v.label.starts(with: "3")})).to(beTrue())
             }
-            
+
             it("does not contain a vertex with a label that ends with .") {
                 expect(TestGraph.directedC4().contains(vertexWith: {v in v.label.hasSuffix(".")})).to(beFalse())
             }
         }
-        
+
         describe("the empty graph") {
             it("does not contain the vertex v") {
                 expect(TestGraph.empty.contains(vertex: vertex_1)).to(beFalse())
             }
-            
+
             it("does not contain a vertex with an even id") {
                 expect(TestGraph.empty.contains(vertexWith: {v in v.id.isMultiple(of: 2)})).to(beFalse())
             }
-            
+
             it("does not contain a vertex with a label that starts with a") {
                 expect(TestGraph.empty.contains(vertexWith: {v in v.label.starts(with: "a")})).to(beFalse())
             }

--- a/Tests/SwiftDependencyGraphsTests/Helpers/TestGraph.swift
+++ b/Tests/SwiftDependencyGraphsTests/Helpers/TestGraph.swift
@@ -1,4 +1,4 @@
-@testable import swift_dependency_graphs
+@testable import DependencyGraphs
 
 typealias TestGraph = DependencyGraph<Vertex>
 
@@ -7,10 +7,10 @@ extension TestGraph {
      Returns an empty graph.
      */
     static var empty: TestGraph { DependencyGraph() }
-    
+
     /**
      The graph C4 looks like this: 1 --> 2 --> 3 --> 4 --> 1.
-     
+
      - Returns: The graph C4.
      - Note: The directed cyclic graph on 4 vertices is usually denoted by $C^4$ or $C\_4$.
      */
@@ -34,7 +34,7 @@ extension TestGraph {
             vertex_3.id: [vertex_4],
             vertex_4.id: [vertex_1],
         ]
-            
+
         return c4
     }
 }

--- a/Tests/SwiftDependencyGraphsTests/SwiftDependencyGraphsTests.swift
+++ b/Tests/SwiftDependencyGraphsTests/SwiftDependencyGraphsTests.swift
@@ -1,5 +1,5 @@
 import Testing
-@testable import swift_dependency_graphs
+@testable import DependencyGraphs
 
 @Test func example() async throws {
     // Write your test here and use APIs like `#expect(...)` to check expected conditions.


### PR DESCRIPTION
Snake Case `swift_dependency_graphs` is rather uncommon