### PR TITLE
Sequence Conformity

### DIFF
--- a/Sources/SwiftDependencyGraphs/DependencyGraph.swift
+++ b/Sources/SwiftDependencyGraphs/DependencyGraph.swift
@@ -1,6 +1,6 @@
 import OrderedCollections
 
-public struct DependencyGraph<V> where V: Hashable, V: Identifiable {
+public struct DependencyGraph<V>: Sequence where V: Hashable, V: Identifiable {
     typealias Edge = (V, V)
     
     /// The vertices of the dependency graph.

--- a/Tests/SwiftDependencyGraphsTests/Dfs/Path.swift
+++ b/Tests/SwiftDependencyGraphsTests/Dfs/Path.swift
@@ -1,6 +1,6 @@
 import Quick
 import Nimble
-@testable import swift_dependency_graphs
+@testable import DependencyGraphs
 
 class DfsPathTests: QuickSpec {
     override class func spec() {

--- a/Tests/SwiftDependencyGraphsTests/SequenceProtocolTests.swift
+++ b/Tests/SwiftDependencyGraphsTests/SequenceProtocolTests.swift
@@ -1,0 +1,13 @@
+import Testing
+
+@Suite("Sequence: for-in")
+struct ForInTests {
+    @Test func directedC4() async throws {
+        let ids: [Int] = []
+        for vertex in TestGraph.directedC4() {
+            ids.append(vertex.id)
+        }
+        
+        #expect(ids == [1, 2, 3, 4])
+    }
+}


### PR DESCRIPTION
`Sequence` conformity could be useful because we get many higher order functions and other nice stuff for free.

Currently, this is WIP since I am not sure how to implement something like:

- the traverse direction
- the node from which to start

With my current approach, I can only do plain DFS over the whole graph. I will continue this after figuring out a few use cases.