### PR TITLE
Add function that removes an edge from the graph

### DIFF
--- a/Sources/SwiftDependencyGraphs/DependencyGraph.swift
+++ b/Sources/SwiftDependencyGraphs/DependencyGraph.swift
@@ -104,4 +104,27 @@ public struct DependencyGraph<V> where V: Hashable, V: Identifiable {
       }
     return edges[vertex.id]
   }
+
+  /// Removes the edge from the graph.
+  /// - Parameter edge: The edge to remove.
+  /// - Returns: The edge if it was in the graph and `nil` otherwise.
+  @discardableResult mutating public func remove(edge: (V, V)) -> (V, V)? {
+    let head = edge.0
+    let tail = edge.1
+
+    guard vertices[head.id] != nil,
+      vertices[tail.id] != nil,
+      // The type ensures that this is true if and only if
+      // incomingEdges[tail.id]?.contains(head) is also true.
+      let isEdgeInGraph = outgoingEdges[head.id]?.contains(tail),
+      isEdgeInGraph
+    else {
+      return nil
+    }
+
+    incomingEdges[tail.id]?.remove(head)
+    outgoingEdges[head.id]?.remove(tail)
+
+    return edge
+  }
 }

--- a/Tests/SwiftDependencyGraphsTests/Remove/RemoveEdge.swift
+++ b/Tests/SwiftDependencyGraphsTests/Remove/RemoveEdge.swift
@@ -1,0 +1,99 @@
+import Testing
+
+@testable import DependencyGraphs
+
+@Suite("Removes edge from graph and") struct RemoveEdgeSuccessfullyTests {
+
+  var graph = TestGraph.path()
+  let edge = (vertex1, vertex2)
+  let result: (Vertex, Vertex)?
+
+  init() {
+    result = graph.remove(edge: edge)
+  }
+
+  @Test("returns the edge") func returnsEdge() {
+    #expect(result.unsafelyUnwrapped == edge)
+  }
+
+  @Test("the incoming edges are modified") func incomingEdges() {
+    #expect(
+      graph.incomingEdges == [
+        vertex1.id: [],
+        vertex2.id: [],
+        vertex3.id: [vertex2],
+        vertex4.id: [vertex3],
+        vertex5.id: [vertex4],
+      ])
+  }
+
+  @Test("the outgoing edges are modified") func outgoingEdges() {
+    #expect(
+      graph.outgoingEdges == [
+        vertex1.id: [],
+        vertex2.id: [vertex3],
+        vertex3.id: [vertex4],
+        vertex4.id: [vertex5],
+        vertex5.id: [],
+      ])
+  }
+
+  @Test("the vertices are not modified") func vertices() {
+    #expect(graph.vertices == TestGraph.path().vertices)
+  }
+}
+
+@Suite("Fails to remove edge from graph") struct RemoveEdgeFailedTests {
+
+  var graph = TestGraph.path()
+
+  @Test("because the head vertex does not exist") mutating func headVertex() {
+    #expect(graph.remove(edge: (vertex7, vertex2)) == nil)
+  }
+
+  @Test("because the tail vertex does not exist") mutating func tailVertex() {
+    #expect(graph.remove(edge: (vertex3, vertex6)) == nil)
+  }
+
+  @Test("because it is in the opposite direction") mutating func oppositeDirection() {
+    #expect(graph.remove(edge: (vertex4, vertex3)) == nil)
+  }
+
+  @Test("because the edge is not in the graph") mutating func headEdge() {
+    #expect(graph.remove(edge: (vertex2, vertex4)) == nil)
+  }
+
+  @Test("because it was already removed") mutating func firstSuccessfulSecondFail() {
+    let edge = (vertex1, vertex2)
+    graph.remove(edge: edge)
+    #expect(graph.remove(edge: edge) == nil)
+  }
+
+  @Test("twice") mutating func twiceFail() {
+    let edge = (vertex2, vertex5)
+    graph.remove(edge: edge)
+    #expect(graph.remove(edge: edge) == nil)
+  }
+}
+
+@Suite("When it fails to remove an edge,") struct NoModificationWhenFailTests {
+  var graph = TestGraph.path()
+
+  init() {
+    graph.remove(edge: (vertex5, vertex1))
+  }
+
+  @Test("the incoming edges are not modified") func incomingEdges() {
+    #expect(
+      graph.incomingEdges == TestGraph.path().incomingEdges)
+  }
+
+  @Test("the outgoing edges are not modified") func outgoingEdges() {
+    #expect(
+      graph.outgoingEdges == TestGraph.path().outgoingEdges)
+  }
+
+  @Test("the vertices are not modified") func vertices() {
+    #expect(graph.vertices == TestGraph.path().vertices)
+  }
+}

--- a/Tests/SwiftDependencyGraphsTests/Remove/RemoveEdge.swift
+++ b/Tests/SwiftDependencyGraphsTests/Remove/RemoveEdge.swift
@@ -68,12 +68,6 @@ import Testing
     graph.remove(edge: edge)
     #expect(graph.remove(edge: edge) == nil)
   }
-
-  @Test("twice") mutating func twiceFail() {
-    let edge = (vertex2, vertex5)
-    graph.remove(edge: edge)
-    #expect(graph.remove(edge: edge) == nil)
-  }
 }
 
 @Suite("When it fails to remove an edge,") struct NoModificationWhenFailTests {

--- a/Tests/SwiftDependencyGraphsTests/Remove/RemoveEdge.swift
+++ b/Tests/SwiftDependencyGraphsTests/Remove/RemoveEdge.swift
@@ -77,6 +77,7 @@ import Testing
 }
 
 @Suite("When it fails to remove an edge,") struct NoModificationWhenFailTests {
+
   var graph = TestGraph.path()
 
   init() {


### PR DESCRIPTION
I am not sure if I should add more sophisticated return values. For example, the return value could indicate whether one of the vertices in not in the graph.

Related to https://github.com/ikelax/swift-dependency-graphs/issues/4.