### PR TITLE
Insert vertex

### DIFF
--- a/Sources/SwiftDependencyGraphs/DependencyGraph.swift
+++ b/Sources/SwiftDependencyGraphs/DependencyGraph.swift
@@ -127,4 +127,21 @@ public struct DependencyGraph<V> where V: Hashable, V: Identifiable {
 
     return edge
   }
+
+  /// Inserts the given vertex into the graph if it is not already present.
+  /// - Parameter newVertex: The vertex to insert.
+  /// - Returns: `(true, newVertex)` if `newVertex` was not contained in the graph.
+  /// If a vertex equal to `newVertex` was already contained in the graph, the method returns `(false, oldVertex)`,
+  /// where `oldVertex` is the vertex that was equal to `newVertex`. In some cases, `oldVertex` may be
+  /// distinguishable from `newVertex` by identity comparison or some other means.
+  @discardableResult mutating public func insert(newVertex: V) -> (
+    inserted: Bool, vertexAfterInsert: V
+  ) {
+    if let oldVertex = vertices[newVertex.id] {
+      return (false, oldVertex)
+    }
+
+    vertices[newVertex.id] = newVertex
+    return (true, newVertex)
+  }
 }

--- a/Sources/SwiftDependencyGraphs/DependencyGraph.swift
+++ b/Sources/SwiftDependencyGraphs/DependencyGraph.swift
@@ -129,7 +129,7 @@ public struct DependencyGraph<V> where V: Hashable, V: Identifiable {
   }
 
   /// Inserts the given vertex into the graph if it is not already present.
-  /// - Parameter newVertex: The vertex to insert.
+  /// - Parameter newVertex: A vertex to insert into the graph.
   /// - Returns: `(true, newVertex)` if `newVertex` was not contained in the graph.
   /// If a vertex equal to `newVertex` was already contained in the graph, the method returns `(false, oldVertex)`,
   /// where `oldVertex` is the vertex that was equal to `newVertex`. In some cases, `oldVertex` may be

--- a/Tests/SwiftDependencyGraphsTests/Insert/InsertVertex.swift
+++ b/Tests/SwiftDependencyGraphsTests/Insert/InsertVertex.swift
@@ -1,0 +1,167 @@
+import Testing
+
+@testable import DependencyGraphs
+
+@Suite("Inserting a new vertex with a unique id and a unique label into the graph")
+struct InsertVertexSuccessfullyTests {
+
+  var graph = TestGraph.path()
+  let newVertex = Vertex(id: 6)
+  let result: (Bool, Vertex)
+
+  init() {
+    result = graph.insert(newVertex: newVertex)
+  }
+
+  @Test("returns that the insertion was successful and the inserted vertex") func returnValue() {
+    #expect(result == (true, newVertex))
+  }
+
+  @Test("does not change the incoming edges") func incomingEdges() {
+    #expect(graph.incomingEdges == TestGraph.path().incomingEdges)
+  }
+
+  @Test("does not change the outgoing edges") func outgoingEdges() {
+    #expect(graph.outgoingEdges == TestGraph.path().outgoingEdges)
+  }
+
+  @Test("changes the vertices") func vertices() {
+    #expect(
+      graph.vertices == [
+        vertex1.id: vertex1,
+        vertex2.id: vertex2,
+        vertex3.id: vertex3,
+        vertex4.id: vertex4,
+        vertex5.id: vertex5,
+        newVertex.id: newVertex,
+      ])
+  }
+}
+
+@Suite("Inserting a new vertex with a unique id and a duplicate label into the graph")
+struct InsertVertexDuplicateLabelSuccessfullyTests {
+
+  var graph = TestGraph.path()
+  let newVertex = Vertex(id: 6, label: "5")
+  let result: (Bool, Vertex)
+
+  init() {
+    result = graph.insert(newVertex: newVertex)
+  }
+
+  @Test("returns that the insertion was successful and the inserted vertex") func returnValue() {
+    #expect(result == (true, newVertex))
+  }
+
+  @Test("does not change the incoming edges") func incomingEdges() {
+    #expect(graph.incomingEdges == TestGraph.path().incomingEdges)
+  }
+
+  @Test("does not change the outgoing edges") func outgoingEdges() {
+    #expect(graph.outgoingEdges == TestGraph.path().outgoingEdges)
+  }
+
+  @Test("changes the vertices") func vertices() {
+    #expect(
+      graph.vertices == [
+        vertex1.id: vertex1,
+        vertex2.id: vertex2,
+        vertex3.id: vertex3,
+        vertex4.id: vertex4,
+        vertex5.id: vertex5,
+        newVertex.id: newVertex,
+      ])
+  }
+}
+
+@Suite("Inserting a new vertex twice into the graph") struct InsertVertexTwiceTests {
+
+  var graph = TestGraph.path()
+  let newVertex = Vertex(id: -1)
+  let result: (Bool, Vertex)
+
+  init() {
+    _ = graph.insert(newVertex: newVertex)
+    result = graph.insert(newVertex: newVertex)
+  }
+
+  @Test("returns that the (second) insertion failed and the existing vertex") func returnValue() {
+    #expect(result == (false, newVertex))
+  }
+
+  @Test("does not change the incoming edges") func incomingEdges() {
+    #expect(graph.incomingEdges == TestGraph.path().incomingEdges)
+  }
+
+  @Test("does not change the outgoing edges") func outgoingEdges() {
+    #expect(graph.outgoingEdges == TestGraph.path().outgoingEdges)
+  }
+
+  @Test("changes the vertices") func vertices() {
+    #expect(
+      graph.vertices == [
+        vertex1.id: vertex1,
+        vertex2.id: vertex2,
+        vertex3.id: vertex3,
+        vertex4.id: vertex4,
+        vertex5.id: vertex5,
+        newVertex.id: newVertex,
+      ])
+  }
+}
+
+@Suite("Does not insert a vertex with a duplicate id and a duplicate label into the graph and")
+struct InsertVertexDuplicateIdAndLabelFailedTests {
+
+  var graph = TestGraph.path()
+  let newVertex = Vertex(id: 5)
+  let result: (Bool, Vertex)
+
+  init() {
+    result = graph.insert(newVertex: newVertex)
+  }
+
+  @Test("returns that the insertion failed and the existing vertex") func returnValue() {
+    #expect(result == (false, newVertex))
+  }
+
+  @Test("does not change the incoming edges") func incomingEdges() {
+    #expect(graph.incomingEdges == TestGraph.path().incomingEdges)
+  }
+
+  @Test("does not change the outgoing edges") func outgoingEdges() {
+    #expect(graph.outgoingEdges == TestGraph.path().outgoingEdges)
+  }
+
+  @Test("does not change the vertices") func vertices() {
+    #expect(graph.vertices == TestGraph.path().vertices)
+  }
+}
+
+@Suite("Does not insert a vertex with a duplicate id and a unique label into the graph and")
+struct InsertVertexDuplicateIdAndUniqueLabelFailedTests {
+
+  var graph = TestGraph.path()
+  let newVertex = Vertex(id: 5, label: "unique")
+  let result: (Bool, Vertex)
+
+  init() {
+    result = graph.insert(newVertex: newVertex)
+  }
+
+  @Test("returns that the insertion failed and the existing vertex") func returnValue() {
+    #expect(result == (false, Vertex(id: 5)))
+  }
+
+  @Test("does not change the incoming edges") func incomingEdges() {
+    #expect(graph.incomingEdges == TestGraph.path().incomingEdges)
+  }
+
+  @Test("does not change the outgoing edges") func outgoingEdges() {
+    #expect(graph.outgoingEdges == TestGraph.path().outgoingEdges)
+  }
+
+  @Test("does not change the vertices") func vertices() {
+    #expect(graph.vertices == TestGraph.path().vertices)
+  }
+}


### PR DESCRIPTION
The behaviour of the function and its signature are copied from the Set
API of the Swift Standard Library. I also copied parts of the
documentation from https://developer.apple.com/documentation/swift/set/insert(_:)-nads.

Two vertices are considered to be equal iff their ids are equal.

So, if a vertex with the id of newVertex is already in the graph, the
function returns (false, vertex). Otherwise, it inserts the vertex and
returns (true, newVertex).

Related to #4.