### PR TITLE
Chore

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,18 +30,19 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           brew install xcbeautify
           set -o pipefail && swift test | xcbeautify --renderer github-actions
-  test-windows:
-    name: Test on Windows Server 2022
-    runs-on: windows-2022
-    steps:
-      - uses: compnerd/gha-setup-swift@main
-        with:
-          branch: swift-6.0-release
-          tag: 6.0-RELEASE
-      - uses: actions/checkout@v4
-      - name: Test
-        run: |
-          Set-StrictMode -Version Latest
-          $ErrorActionPreference = "Stop"
-          $PSNativeCommandUseErrorActionPreference = $true
-          swift test
+  # See https://github.com/ikelax/swift-dependency-graphs/issues/28
+  # test-windows:
+  #   name: Test on Windows Server 2022
+  #   runs-on: windows-2022
+  #   steps:
+  #     - uses: compnerd/gha-setup-swift@main
+  #       with:
+  #         branch: swift-6.0-release
+  #         tag: 6.0-RELEASE
+  #     - uses: actions/checkout@v4
+  #     - name: Test
+  #       run: |
+  #         Set-StrictMode -Version Latest
+  #         $ErrorActionPreference = "Stop"
+  #         $PSNativeCommandUseErrorActionPreference = $true
+  #         swift test

--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "lineLength": 120,
+  "indentation": {
+    "spaces": 2
+  },
+  "rules": {
+    "OrderedImports": true
+  }
+}

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,8 @@
+type_name:
+  max_length:
+    warning: 50
+    error: 50
+
 disabled_rules:
   - trailing_comma
 


### PR DESCRIPTION
The test job on Windows was commented out because it currently fails
since the compilation on Windows fails.

See https://github.com/ikelax/swift-dependency-graphs/issues/28.

By default, the line length is 100. I like 120 more because XCode only
shows the suite description while scrolling if it is on the same line as
the struct. Therefore, I configure swift-format accordingly.

The names for the structs of test suites can become quite long. So, I
increased the maximum length of allowed type names in SwiftLint.