### PR TITLE
Remove vertex

### DIFF
--- a/Sources/SwiftDependencyGraphs/DependencyGraph.swift
+++ b/Sources/SwiftDependencyGraphs/DependencyGraph.swift
@@ -110,8 +110,8 @@ public struct DependencyGraph<V> where V: Hashable, V: Identifiable, V: Sendable
   /// Removes a vertex from the graph.
   /// - Parameters:
   ///   - vertex: The removed vertex.
-  ///   - isForced: Whether the vertex is removed by force. Defaults to false. If `false` the vertex is removed
-  ///   iff it does not have edges to other vertices. If `true` the edges to other vertices are also removed.
+  ///   - isForced: `true` to also remove edges to other vertices if there are any.
+  ///   `false` to remove `vertex` iff it has no edges to other vertices.
   /// - Returns: The result of the removal. If successful, the removed vertex and edges are returned.
   /// Otherwise, the reason for the failure is returned.
   @discardableResult mutating public func remove(vertex: V, byForce isForced: Bool = false) -> RemoveVertexResult {

--- a/Sources/SwiftDependencyGraphs/DependencyGraph.swift
+++ b/Sources/SwiftDependencyGraphs/DependencyGraph.swift
@@ -113,7 +113,8 @@ public struct DependencyGraph<V> where V: Hashable, V: Identifiable, V: Sendable
     }
 
     // The default values in the coalesces are only for the type system.
-    // In a bug-free library, the values should always exist and therefore not be nil.
+    // In a bug-free library, the values should always exist
+    // because the vertex is in the graph and therefore not be nil.
     if isForced {
       return .success(
         RemoveVertexSuccess<V>(

--- a/Sources/SwiftDependencyGraphs/DependencyGraph.swift
+++ b/Sources/SwiftDependencyGraphs/DependencyGraph.swift
@@ -113,7 +113,7 @@ public struct DependencyGraph<V> where V: Hashable, V: Identifiable, V: Sendable
     }
 
     // The default values in the coalesces are only for the type system.
-    // In a bug-free library, the values should always exists and therefore not be nil.
+    // In a bug-free library, the values should always exist and therefore not be nil.
     if isForced {
       return .success(
         RemoveVertexSuccess<V>(

--- a/Sources/SwiftDependencyGraphs/DependencyGraph.swift
+++ b/Sources/SwiftDependencyGraphs/DependencyGraph.swift
@@ -110,9 +110,10 @@ public struct DependencyGraph<V> where V: Hashable, V: Identifiable, V: Sendable
   /// Removes a vertex from the graph.
   /// - Parameters:
   ///   - vertex: The removed vertex.
-  ///   - isForced: Whether the vertex is removed by force. Defaults to false. If `false` the vertex is removed iff it does not have edges to other vertices.
-  ///   If `true` the edges to other vertices are also removed.
-  /// - Returns: The result of the removal. If successful, the removed vertex and edges are returned. Otherwise, the reason for the failure is returned.
+  ///   - isForced: Whether the vertex is removed by force. Defaults to false. If `false` the vertex is removed
+  ///   iff it does not have edges to other vertices. If `true` the edges to other vertices are also removed.
+  /// - Returns: The result of the removal. If successful, the removed vertex and edges are returned.
+  /// Otherwise, the reason for the failure is returned.
   @discardableResult mutating public func remove(vertex: V, byForce isForced: Bool = false) -> RemoveVertexResult {
     guard vertices[vertex.id] != nil else {
       return .failure(RemoveVertexError.notInGraph(vertex))

--- a/Sources/SwiftDependencyGraphs/DependencyGraph.swift
+++ b/Sources/SwiftDependencyGraphs/DependencyGraph.swift
@@ -1,6 +1,6 @@
 import OrderedCollections
 
-public struct DependencyGraph<V> where V: Hashable, V: Identifiable {
+public struct DependencyGraph<V> where V: Hashable, V: Identifiable, V: Sendable {
   typealias Edge = (V, V)
 
   /// The vertices of the dependency graph.
@@ -103,6 +103,41 @@ public struct DependencyGraph<V> where V: Hashable, V: Identifiable {
         incomingEdges
       }
     return edges[vertex.id]
+  }
+
+  public typealias RemoveVertexResult = Result<RemoveVertexSuccess<V>, RemoveVertexError<V>>
+
+  @discardableResult mutating public func remove(vertex: V, byForce isForced: Bool = false) -> RemoveVertexResult {
+    guard let removedVertex = vertices.removeValue(forKey: vertex.id) else {
+      return .failure(RemoveVertexError.notInGraph(vertex))
+    }
+
+    // The default values in the coalesces are only for the type system.
+    // In a bug-free library, the values should always exists and therefore not be nil.
+    if isForced {
+      return .success(
+        RemoveVertexSuccess<V>(
+          vertex: removedVertex,
+          outgoingEdges: outgoingEdges.removeValue(forKey: vertex.id) ?? [],
+          incomingEdges: incomingEdges.removeValue(forKey: vertex.id) ?? []
+        )
+      )
+    }
+
+    guard let outgoingEdges = outgoingEdges[vertex.id],
+      outgoingEdges.isEmpty,
+      let incomingEdges = incomingEdges[vertex.id],
+      incomingEdges.isEmpty
+    else {
+      return .failure(
+        RemoveVertexError.hasEdgesTo(
+          incoming: incomingEdges[vertex.id] ?? [],
+          outgoing: outgoingEdges[vertex.id] ?? []
+        )
+      )
+    }
+
+    return .success(RemoveVertexSuccess(vertex: vertex, outgoingEdges: [], incomingEdges: []))
   }
 
   /// Removes the edge from the graph.

--- a/Sources/SwiftDependencyGraphs/DependencyGraph.swift
+++ b/Sources/SwiftDependencyGraphs/DependencyGraph.swift
@@ -107,6 +107,12 @@ public struct DependencyGraph<V> where V: Hashable, V: Identifiable, V: Sendable
 
   public typealias RemoveVertexResult = Result<RemoveVertexSuccess<V>, RemoveVertexError<V>>
 
+  /// Removes a vertex from the graph.
+  /// - Parameters:
+  ///   - vertex: The removed vertex.
+  ///   - isForced: Whether the vertex is removed by force. Defaults to false. If `false` the vertex is removed iff it does not have edges to other vertices.
+  ///   If `true` the edges to other vertices are also removed.
+  /// - Returns: The result of the removal. If successful, the removed vertex and edges are returned. Otherwise, the reason for the failure is returned.
   @discardableResult mutating public func remove(vertex: V, byForce isForced: Bool = false) -> RemoveVertexResult {
     guard vertices[vertex.id] != nil else {
       return .failure(RemoveVertexError.notInGraph(vertex))

--- a/Sources/SwiftDependencyGraphs/RemoveVertexError.swift
+++ b/Sources/SwiftDependencyGraphs/RemoveVertexError.swift
@@ -1,0 +1,7 @@
+import OrderedCollections
+
+public enum RemoveVertexError<V: Sendable & Hashable>: Error {
+  case notInGraph(_ vertex: V)
+
+  case hasEdgesTo(incoming: OrderedSet<V>, outgoing: OrderedSet<V>)
+}

--- a/Sources/SwiftDependencyGraphs/RemoveVertexError.swift
+++ b/Sources/SwiftDependencyGraphs/RemoveVertexError.swift
@@ -1,6 +1,6 @@
 import OrderedCollections
 
-public enum RemoveVertexError<V: Sendable & Hashable>: Error {
+public enum RemoveVertexError<V: Sendable & Hashable>: Error, Equatable {
   case notInGraph(_ vertex: V)
 
   case hasEdgesTo(incoming: OrderedSet<V>, outgoing: OrderedSet<V>)

--- a/Sources/SwiftDependencyGraphs/RemoveVertexSuccess.swift
+++ b/Sources/SwiftDependencyGraphs/RemoveVertexSuccess.swift
@@ -1,6 +1,6 @@
 import OrderedCollections
 
-public struct RemoveVertexSuccess<V: Hashable> {
+public struct RemoveVertexSuccess<V: Hashable>: Equatable {
   let vertex: V
   let outgoingEdges: OrderedSet<V>
   let incomingEdges: OrderedSet<V>

--- a/Sources/SwiftDependencyGraphs/RemoveVertexSuccess.swift
+++ b/Sources/SwiftDependencyGraphs/RemoveVertexSuccess.swift
@@ -1,7 +1,14 @@
 import OrderedCollections
 
 public struct RemoveVertexSuccess<V: Hashable>: Equatable {
+  typealias RemovedEdges = OrderedSet<V>
+
+  /// The removed vertex.
   let vertex: V
-  let outgoingEdges: OrderedSet<V>
-  let incomingEdges: OrderedSet<V>
+  /// The outgoing edges that have been removed with the vertex. The set is only non-empty
+  /// if the vertex was removed by force.
+  let outgoingEdges: RemovedEdges
+  /// The incoming edges that have been removed with the vertex. The set is only non-empty
+  /// if the vertex was removed by force.
+  let incomingEdges: RemovedEdges
 }

--- a/Sources/SwiftDependencyGraphs/RemoveVertexSuccess.swift
+++ b/Sources/SwiftDependencyGraphs/RemoveVertexSuccess.swift
@@ -1,0 +1,7 @@
+import OrderedCollections
+
+public struct RemoveVertexSuccess<V: Hashable> {
+  let vertex: V
+  let outgoingEdges: OrderedSet<V>
+  let incomingEdges: OrderedSet<V>
+}

--- a/Sources/SwiftDependencyGraphs/RemoveVertexSuccess.swift
+++ b/Sources/SwiftDependencyGraphs/RemoveVertexSuccess.swift
@@ -1,7 +1,10 @@
 import OrderedCollections
 
 public struct RemoveVertexSuccess<V: Hashable>: Equatable {
-  typealias RemovedEdges = OrderedSet<V>
+
+  struct RemovedEdges: Equatable {
+    let edges: OrderedSet<V>
+  }
 
   /// The removed vertex.
   let vertex: V
@@ -11,4 +14,10 @@ public struct RemoveVertexSuccess<V: Hashable>: Equatable {
   /// The incoming edges that have been removed with the vertex. The set is only non-empty
   /// if the vertex was removed by force.
   let incomingEdges: RemovedEdges
+
+  init(vertex: V, outgoingEdges: OrderedSet<V>, incomingEdges: OrderedSet<V>) {
+    self.vertex = vertex
+    self.outgoingEdges = RemovedEdges(edges: outgoingEdges)
+    self.incomingEdges = RemovedEdges(edges: incomingEdges)
+  }
 }

--- a/Tests/SwiftDependencyGraphsTests/Helpers/TestGraph.swift
+++ b/Tests/SwiftDependencyGraphsTests/Helpers/TestGraph.swift
@@ -188,4 +188,22 @@ extension TestGraph {
 
     return complementOfK3
   }
+
+  static func oneVertex() -> TestGraph {
+    var graph = TestGraph()
+
+    graph.vertices = [
+      vertex1.id: vertex1
+    ]
+
+    graph.incomingEdges = [
+      vertex1.id: []
+    ]
+
+    graph.outgoingEdges = [
+      vertex1.id: []
+    ]
+
+    return graph
+  }
 }

--- a/Tests/SwiftDependencyGraphsTests/Helpers/Vertex.swift
+++ b/Tests/SwiftDependencyGraphsTests/Helpers/Vertex.swift
@@ -13,6 +13,7 @@ let vertex4 = Vertex(id: 4)
 let vertex5 = Vertex(id: 5)
 let vertex6 = Vertex(id: 6)
 let vertex7 = Vertex(id: 7)
+let vertex8 = Vertex(id: 8)
 
 let emptyVertexList: [Vertex] = []
 

--- a/Tests/SwiftDependencyGraphsTests/Helpers/Vertex.swift
+++ b/Tests/SwiftDependencyGraphsTests/Helpers/Vertex.swift
@@ -1,6 +1,6 @@
 /// In comments or descriptions, a vertex with `id` `n` is referred to as `v${n}`.
 /// Just using the `id` or the `label` may be confusing.
-struct Vertex: Identifiable, Hashable {
+struct Vertex: Identifiable, Hashable, Sendable {
   let id: Int
   /// `label` is used for testing how the library handles properties.
   let label: String

--- a/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
+++ b/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
@@ -151,33 +151,36 @@ import Testing
   }
 }
 
-@Suite("Failing to remove a vertex") struct RemoveVertexNotInGraphFailedTests {
+@Suite("Failing to remove a vertex") struct RemoveVertexFailedTests {
 
-  var graph = TestGraph.binaryTree()
-  let vertex = vertex8
-  let result: DependencyGraph<Vertex>.RemoveVertexResult
+  @Suite("because the vertex was not in the graph") struct NotInGraphTests {
 
-  init() {
-    result = graph.remove(vertex: vertex)
-  }
+    var graph = TestGraph.binaryTree()
+    let vertex = vertex8
+    let result: DependencyGraph<Vertex>.RemoveVertexResult
 
-  @Test("returns that the removal failed because the vertex was not in the graph") func success() {
-    #expect(result == .failure(.notInGraph(vertex)))
-  }
+    init() {
+      result = graph.remove(vertex: vertex)
+    }
 
-  @Test("does not change the incoming edges") func incomingEdges() {
-    #expect(
-      graph.incomingEdges == TestGraph.binaryTree().incomingEdges
-    )
-  }
+    @Test("returns that the removal failed") func success() {
+      #expect(result == .failure(.notInGraph(vertex)))
+    }
 
-  @Test("does not change the outgoing edges") func outgoingEdges() {
-    #expect(
-      graph.outgoingEdges == TestGraph.binaryTree().outgoingEdges
-    )
-  }
+    @Test("does not change the incoming edges") func incomingEdges() {
+      #expect(
+        graph.incomingEdges == TestGraph.binaryTree().incomingEdges
+      )
+    }
 
-  @Test("does not change the vertices") func vertices() {
-    #expect(graph.vertices == TestGraph.binaryTree().vertices)
+    @Test("does not change the outgoing edges") func outgoingEdges() {
+      #expect(
+        graph.outgoingEdges == TestGraph.binaryTree().outgoingEdges
+      )
+    }
+
+    @Test("does not change the vertices") func vertices() {
+      #expect(graph.vertices == TestGraph.binaryTree().vertices)
+    }
   }
 }

--- a/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
+++ b/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
@@ -1,4 +1,3 @@
-// try remove vertex not in graph
 // try remove vertex with tail
 // try remove vertex with head
 // try remove vertex with tail and head
@@ -16,7 +15,7 @@ import Testing
   init() {
     result = graph.remove(vertex: vertex)
   }
-  
+
   @Test("returns that the removal was successful and the removed vertex") func success() {
     #expect(result == .success(.init(vertex: vertex, outgoingEdges: [], incomingEdges: [])))
   }
@@ -48,8 +47,9 @@ import Testing
     init() {
       result = graph.remove(vertex: vertex, byForce: true)
     }
-    
-    @Test("returns that the removal was successful, the removed vertex and no edges because there weren't any") func success() {
+
+    @Test("returns that the removal was successful, the removed vertex and no edges because there weren't any")
+    func success() {
       #expect(result == .success(.init(vertex: vertex, outgoingEdges: [], incomingEdges: [])))
     }
 
@@ -69,7 +69,7 @@ import Testing
       #expect(graph.vertices == [:])
     }
   }
-  
+
   @Suite("from the graph with a path") struct PathTests {
     var graph = TestGraph.path()
     let vertex = vertex2
@@ -78,8 +78,9 @@ import Testing
     init() {
       result = graph.remove(vertex: vertex, byForce: true)
     }
-    
-    @Test("returns that the removal was successful and the removed vertex and edges", .disabled("This is a know bug.")) func success() {
+
+    @Test("returns that the removal was successful and the removed vertex and edges", .disabled("This is a know bug."))
+    func success() {
       #expect(result == .success(.init(vertex: vertex, outgoingEdges: [], incomingEdges: [])))
     }
 
@@ -108,11 +109,11 @@ import Testing
     @Test("changes the vertices") func vertices() {
       #expect(
         graph.vertices == [
-        vertex1.id: vertex1,
-        vertex3.id: vertex3,
-        vertex4.id: vertex4,
-        vertex5.id: vertex5,
-      ]
+          vertex1.id: vertex1,
+          vertex3.id: vertex3,
+          vertex4.id: vertex4,
+          vertex5.id: vertex5,
+        ]
       )
     }
   }
@@ -128,7 +129,7 @@ import Testing
     _ = graph.remove(vertex: vertex)
     result = graph.remove(vertex: vertex)
   }
-  
+
   @Test("returns that the removal failed and the vertex that could not be found") func returnsVertex() {
     #expect(result == .failure(.notInGraph(vertex)))
   }
@@ -147,5 +148,36 @@ import Testing
 
   @Test("changes the vertices") func vertices() {
     #expect(graph.vertices == [:])
+  }
+}
+
+@Suite("Failing to remove a vertex") struct RemoveVertexNotInGraphFailedTests {
+
+  var graph = TestGraph.binaryTree()
+  let vertex = vertex8
+  let result: DependencyGraph<Vertex>.RemoveVertexResult
+
+  init() {
+    result = graph.remove(vertex: vertex)
+  }
+
+  @Test("returns that the removal failed because the vertex was not in the graph") func success() {
+    #expect(result == .failure(.notInGraph(vertex)))
+  }
+
+  @Test("does not change the incoming edges") func incomingEdges() {
+    #expect(
+      graph.incomingEdges == TestGraph.binaryTree().incomingEdges
+    )
+  }
+
+  @Test("does not change the outgoing edges") func outgoingEdges() {
+    #expect(
+      graph.outgoingEdges == TestGraph.binaryTree().outgoingEdges
+    )
+  }
+
+  @Test("does not change the vertices") func vertices() {
+    #expect(graph.vertices == TestGraph.binaryTree().vertices)
   }
 }

--- a/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
+++ b/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
@@ -17,14 +17,8 @@ import Testing
     result = graph.remove(vertex: vertex)
   }
   
-  @Test("returns that the removal was successful") func success() {
-    #expect(throws: Never.self) {
-      try result.get()
-    }
-  }
-  
-  @Test("returns the removed vertex") func returnsVertex() {
-    #expect(try! result.get().vertex == vertex)
+  @Test("returns that the removal was successful and the removed vertex") func success() {
+    #expect(result == .success(.init(vertex: vertex, outgoingEdges: [], incomingEdges: [])))
   }
 
   @Test("does not change the incoming edges") func incomingEdges() {
@@ -54,23 +48,9 @@ import Testing
     init() {
       result = graph.remove(vertex: vertex, byForce: true)
     }
-
-    @Test("returns that the removal was successful") func success() {
-      #expect(throws: Never.self) {
-        try result.get()
-      }
-    }
     
-    @Test("returns the removed vertex") func returnsVertex() {
-      #expect(try! result.get().vertex == vertex)
-    }
-    
-    @Test("returns no incoming edges because there were not any") func returnsNoIncomingEdges() {
-      #expect(try! result.get().incomingEdges == [])
-    }
-    
-    @Test("returns no outgoing edges because there were not any") func returnsNoOutgoingEdges() {
-      #expect(try! result.get().outgoingEdges == [])
+    @Test("returns that the removal was successful, the removed vertex and no edges because there weren't any") func success() {
+      #expect(result == .success(.init(vertex: vertex, outgoingEdges: [], incomingEdges: [])))
     }
 
     @Test("does not change the incoming edges", .disabled("This is a know bug.")) func incomingEdges() {
@@ -98,23 +78,9 @@ import Testing
     init() {
       result = graph.remove(vertex: vertex, byForce: true)
     }
-
-    @Test("returns that the removal was successful") func success() {
-      #expect(throws: Never.self) {
-        try result.get()
-      }
-    }
     
-    @Test("returns the removed vertex") func returnsVertex() {
-      #expect(try! result.get().vertex == vertex)
-    }
-    
-    @Test("returns the removed incoming edges", .disabled("This is a know bug.")) func returnsIncomingEdges() {
-      #expect(try! result.get().incomingEdges == [])
-    }
-    
-    @Test("returns the removed outgoing edges", .disabled("This is a know bug.")) func returnsOutgoingEdges() {
-      #expect(try! result.get().outgoingEdges == [])
+    @Test("returns that the removal was successful and the removed vertex and edges", .disabled("This is a know bug.")) func success() {
+      #expect(result == .success(.init(vertex: vertex, outgoingEdges: [], incomingEdges: [])))
     }
 
     @Test("changes the incoming edges", .disabled("This is a know bug.")) func incomingEdges() {

--- a/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
+++ b/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
@@ -1,4 +1,3 @@
-// remove twice
 // try remove vertex not in graph
 // try remove vertex with tail
 // try remove vertex with head
@@ -150,5 +149,37 @@ import Testing
       ]
       )
     }
+  }
+}
+
+@Suite("Removing a vertex twice") struct TryRemoveVertexTwiceTests {
+
+  var graph = TestGraph.oneVertex()
+  let vertex = vertex1
+  let result: DependencyGraph<Vertex>.RemoveVertexResult
+
+  init() {
+    _ = graph.remove(vertex: vertex)
+    result = graph.remove(vertex: vertex)
+  }
+  
+  @Test("returns that the removal failed and the vertex that could not be found") func returnsVertex() {
+    #expect(result == .failure(.notInGraph(vertex)))
+  }
+
+  @Test("does not change the incoming edges") func incomingEdges() {
+    #expect(
+      graph.incomingEdges == TestGraph.oneVertex().incomingEdges
+    )
+  }
+
+  @Test("does not change the outgoing edges") func outgoingEdges() {
+    #expect(
+      graph.outgoingEdges == TestGraph.oneVertex().outgoingEdges
+    )
+  }
+
+  @Test("changes the vertices") func vertices() {
+    #expect(graph.vertices == [:])
   }
 }

--- a/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
+++ b/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
@@ -1,7 +1,3 @@
-// try remove vertex with tail
-// try remove vertex with head
-// try remove vertex with tail and head
-
 import Testing
 
 @testable import DependencyGraphs
@@ -165,6 +161,99 @@ import Testing
 
     @Test("returns that the removal failed") func success() {
       #expect(result == .failure(.notInGraph(vertex)))
+    }
+
+    @Test("does not change the incoming edges") func incomingEdges() {
+      #expect(
+        graph.incomingEdges == TestGraph.binaryTree().incomingEdges
+      )
+    }
+
+    @Test("does not change the outgoing edges") func outgoingEdges() {
+      #expect(
+        graph.outgoingEdges == TestGraph.binaryTree().outgoingEdges
+      )
+    }
+
+    @Test("does not change the vertices") func vertices() {
+      #expect(graph.vertices == TestGraph.binaryTree().vertices)
+    }
+  }
+  
+  @Suite("because the vertex has an incoming edge") struct IncomingEdgeTests {
+
+    var graph = TestGraph.binaryTree()
+    let vertex = vertex7
+    let result: DependencyGraph<Vertex>.RemoveVertexResult
+
+    init() {
+      result = graph.remove(vertex: vertex)
+    }
+
+    @Test("returns that the removal failed") func success() {
+      #expect(result == .failure(.hasEdgesTo(incoming: [vertex3], outgoing: [])))
+    }
+
+    @Test("does not change the incoming edges") func incomingEdges() {
+      #expect(
+        graph.incomingEdges == TestGraph.binaryTree().incomingEdges
+      )
+    }
+
+    @Test("does not change the outgoing edges") func outgoingEdges() {
+      #expect(
+        graph.outgoingEdges == TestGraph.binaryTree().outgoingEdges
+      )
+    }
+
+    @Test("does not change the vertices") func vertices() {
+      #expect(graph.vertices == TestGraph.binaryTree().vertices)
+    }
+  }
+  
+  @Suite("because the vertex has outgoing edges") struct OutgoingEdgesTests {
+
+    var graph = TestGraph.binaryTree()
+    let vertex = vertex1
+    let result: DependencyGraph<Vertex>.RemoveVertexResult
+
+    init() {
+      result = graph.remove(vertex: vertex)
+    }
+
+    @Test("returns that the removal failed") func success() {
+      #expect(result == .failure(.hasEdgesTo(incoming: [], outgoing: [vertex2, vertex3])))
+    }
+
+    @Test("does not change the incoming edges") func incomingEdges() {
+      #expect(
+        graph.incomingEdges == TestGraph.binaryTree().incomingEdges
+      )
+    }
+
+    @Test("does not change the outgoing edges") func outgoingEdges() {
+      #expect(
+        graph.outgoingEdges == TestGraph.binaryTree().outgoingEdges
+      )
+    }
+
+    @Test("does not change the vertices") func vertices() {
+      #expect(graph.vertices == TestGraph.binaryTree().vertices)
+    }
+  }
+  
+  @Suite("because the vertex has incoming and outgoing edges") struct IncomingAndOutgoingEdgesTests {
+
+    var graph = TestGraph.binaryTree()
+    let vertex = vertex3
+    let result: DependencyGraph<Vertex>.RemoveVertexResult
+
+    init() {
+      result = graph.remove(vertex: vertex)
+    }
+
+    @Test("returns that the removal failed") func success() {
+      #expect(result == .failure(.hasEdgesTo(incoming: [vertex1], outgoing: [vertex6, vertex7])))
     }
 
     @Test("does not change the incoming edges") func incomingEdges() {

--- a/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
+++ b/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
@@ -49,13 +49,21 @@ import Testing
       #expect(result == .success(.init(vertex: vertex, outgoingEdges: [], incomingEdges: [])))
     }
 
-    @Test("does not change the incoming edges", .disabled("This is a know bug.")) func incomingEdges() {
+    @Test(
+      "does not change the incoming edges",
+      .disabled("This is a know bug."),
+      .bug("https://github.com/ikelax/swift-dependency-graphs/issues/38")
+    ) func incomingEdges() {
       #expect(
         graph.incomingEdges == TestGraph.oneVertex().incomingEdges
       )
     }
 
-    @Test("does not change the outgoing edges", .disabled("This is a know bug.")) func outgoingEdges() {
+    @Test(
+      "does not change the outgoing edges",
+      .disabled("This is a know bug."),
+      .bug("https://github.com/ikelax/swift-dependency-graphs/issues/38")
+    ) func outgoingEdges() {
       #expect(
         graph.outgoingEdges == TestGraph.oneVertex().outgoingEdges
       )
@@ -75,12 +83,19 @@ import Testing
       result = graph.remove(vertex: vertex, byForce: true)
     }
 
-    @Test("returns that the removal was successful and the removed vertex and edges", .disabled("This is a know bug."))
-    func success() {
+    @Test(
+      "returns that the removal was successful and the removed vertex and edges",
+      .disabled("This is a know bug."),
+      .bug("https://github.com/ikelax/swift-dependency-graphs/issues/38")
+    ) func success() {
       #expect(result == .success(.init(vertex: vertex, outgoingEdges: [], incomingEdges: [])))
     }
 
-    @Test("changes the incoming edges", .disabled("This is a know bug.")) func incomingEdges() {
+    @Test(
+      "changes the incoming edges",
+      .disabled("This is a know bug."),
+      .bug("https://github.com/ikelax/swift-dependency-graphs/issues/38")
+    ) func incomingEdges() {
       #expect(
         graph.incomingEdges == [
           vertex1.id: [],
@@ -91,7 +106,11 @@ import Testing
       )
     }
 
-    @Test("changes the outgoing edges", .disabled("This is a know bug.")) func outgoingEdges() {
+    @Test(
+      "changes the outgoing edges",
+      .disabled("This is a know bug."),
+      .bug("https://github.com/ikelax/swift-dependency-graphs/issues/38")
+    ) func outgoingEdges() {
       #expect(
         graph.outgoingEdges == [
           vertex1.id: [],

--- a/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
+++ b/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
@@ -179,7 +179,7 @@ import Testing
       #expect(graph.vertices == TestGraph.binaryTree().vertices)
     }
   }
-  
+
   @Suite("because the vertex has an incoming edge") struct IncomingEdgeTests {
 
     var graph = TestGraph.binaryTree()
@@ -210,7 +210,7 @@ import Testing
       #expect(graph.vertices == TestGraph.binaryTree().vertices)
     }
   }
-  
+
   @Suite("because the vertex has outgoing edges") struct OutgoingEdgesTests {
 
     var graph = TestGraph.binaryTree()
@@ -241,7 +241,7 @@ import Testing
       #expect(graph.vertices == TestGraph.binaryTree().vertices)
     }
   }
-  
+
   @Suite("because the vertex has incoming and outgoing edges") struct IncomingAndOutgoingEdgesTests {
 
     var graph = TestGraph.binaryTree()

--- a/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
+++ b/Tests/SwiftDependencyGraphsTests/Remove/RemoveVertexTests.swift
@@ -1,0 +1,154 @@
+// remove twice
+// try remove vertex not in graph
+// try remove vertex with tail
+// try remove vertex with head
+// try remove vertex with tail and head
+
+import Testing
+
+@testable import DependencyGraphs
+
+@Suite("Removing a vertex") struct RemoveVertexSuccessfullyTests {
+
+  var graph = TestGraph.oneVertex()
+  let vertex = vertex1
+  let result: DependencyGraph<Vertex>.RemoveVertexResult
+
+  init() {
+    result = graph.remove(vertex: vertex)
+  }
+  
+  @Test("returns that the removal was successful") func success() {
+    #expect(throws: Never.self) {
+      try result.get()
+    }
+  }
+  
+  @Test("returns the removed vertex") func returnsVertex() {
+    #expect(try! result.get().vertex == vertex)
+  }
+
+  @Test("does not change the incoming edges") func incomingEdges() {
+    #expect(
+      graph.incomingEdges == TestGraph.oneVertex().incomingEdges
+    )
+  }
+
+  @Test("does not change the outgoing edges") func outgoingEdges() {
+    #expect(
+      graph.outgoingEdges == TestGraph.oneVertex().outgoingEdges
+    )
+  }
+
+  @Test("changes the vertices") func vertices() {
+    #expect(graph.vertices == [:])
+  }
+}
+
+@Suite("Forced removing a vertex") struct ForcedRemoveVertexSuccessfullyTests {
+
+  @Suite("from the graph with a single vertex") struct OneVertexTests {
+    var graph = TestGraph.oneVertex()
+    let vertex = vertex1
+    let result: DependencyGraph<Vertex>.RemoveVertexResult
+
+    init() {
+      result = graph.remove(vertex: vertex, byForce: true)
+    }
+
+    @Test("returns that the removal was successful") func success() {
+      #expect(throws: Never.self) {
+        try result.get()
+      }
+    }
+    
+    @Test("returns the removed vertex") func returnsVertex() {
+      #expect(try! result.get().vertex == vertex)
+    }
+    
+    @Test("returns no incoming edges because there were not any") func returnsNoIncomingEdges() {
+      #expect(try! result.get().incomingEdges == [])
+    }
+    
+    @Test("returns no outgoing edges because there were not any") func returnsNoOutgoingEdges() {
+      #expect(try! result.get().outgoingEdges == [])
+    }
+
+    @Test("does not change the incoming edges", .disabled("This is a know bug.")) func incomingEdges() {
+      #expect(
+        graph.incomingEdges == TestGraph.oneVertex().incomingEdges
+      )
+    }
+
+    @Test("does not change the outgoing edges", .disabled("This is a know bug.")) func outgoingEdges() {
+      #expect(
+        graph.outgoingEdges == TestGraph.oneVertex().outgoingEdges
+      )
+    }
+
+    @Test("changes the vertices") func vertices() {
+      #expect(graph.vertices == [:])
+    }
+  }
+  
+  @Suite("from the graph with a path") struct PathTests {
+    var graph = TestGraph.path()
+    let vertex = vertex2
+    let result: DependencyGraph<Vertex>.RemoveVertexResult
+
+    init() {
+      result = graph.remove(vertex: vertex, byForce: true)
+    }
+
+    @Test("returns that the removal was successful") func success() {
+      #expect(throws: Never.self) {
+        try result.get()
+      }
+    }
+    
+    @Test("returns the removed vertex") func returnsVertex() {
+      #expect(try! result.get().vertex == vertex)
+    }
+    
+    @Test("returns the removed incoming edges", .disabled("This is a know bug.")) func returnsIncomingEdges() {
+      #expect(try! result.get().incomingEdges == [])
+    }
+    
+    @Test("returns the removed outgoing edges", .disabled("This is a know bug.")) func returnsOutgoingEdges() {
+      #expect(try! result.get().outgoingEdges == [])
+    }
+
+    @Test("changes the incoming edges", .disabled("This is a know bug.")) func incomingEdges() {
+      #expect(
+        graph.incomingEdges == [
+          vertex1.id: [],
+          vertex3.id: [],
+          vertex4.id: [vertex3],
+          vertex5.id: [vertex4],
+        ]
+      )
+    }
+
+    @Test("changes the outgoing edges", .disabled("This is a know bug.")) func outgoingEdges() {
+      #expect(
+        graph.outgoingEdges == [
+          vertex1.id: [],
+          vertex3.id: [vertex4],
+          vertex4.id: [vertex5],
+          vertex5.id: [],
+        ]
+      )
+    }
+
+    @Test("changes the vertices") func vertices() {
+      #expect(
+        graph.vertices == [
+        vertex1.id: vertex1,
+        vertex3.id: vertex3,
+        vertex4.id: vertex4,
+        vertex5.id: vertex5,
+      ]
+      )
+    }
+  }
+}


### PR DESCRIPTION
The method remove(vertex: V, byForce: Bool) -> RemoveVertexResult is
added, which removes a vertex iff it has no edges to other vertices. If
`byForce` is set to `true`, this restriction is ignored and the edges to
other vertices are also removed.

Currently, there is a known bug. Forced removal does not return all
edges from the graph as you see in the disabled tests. To fix this I
created https://github.com/ikelax/swift-dependency-graphs/issues/38.

The conformity of V to Sendable was added because it is required for
parametrized tests in swift-testing.

For remove(vertex:byForce), I chose a Result type instead of an optional
type for having more expressive return values, especially reasons for
failures.

See also https://github.com/ikelax/swift-dependency-graphs/issues/38.
Related to https://github.com/ikelax/swift-dependency-graphs/issues/4.